### PR TITLE
[IMP] crowdfunding: be more website editor friendly

### DIFF
--- a/crowdfunding/models/crowdfunding_challenge.py
+++ b/crowdfunding/models/crowdfunding_challenge.py
@@ -9,7 +9,12 @@ from odoo.addons.http_routing.models.ir_http import slug
 class CrowdfundingChallenge(models.Model):
     _name = "crowdfunding.challenge"
     _description = "Crowdfunding challenge"
-    _inherit = ["mail.thread", "website.published.mixin", "website.seo.metadata"]
+    _inherit = [
+        "mail.thread",
+        "website.published.mixin",
+        "website.seo.metadata",
+        "website.cover_properties.mixin",
+    ]
     _mail_post_access = "read"
     _mail_flat_thread = False
 

--- a/crowdfunding/templates/crowdfunding_challenge.xml
+++ b/crowdfunding/templates/crowdfunding_challenge.xml
@@ -5,12 +5,7 @@
     <template id="template_challenge_list" name="Crowdfunding">
         <t t-call="website.layout">
             <div id="wrap">
-                <nav class="navbar navbar-light border-top">
-                    <div class="container">
-                        Crowdfunding
-                    </div>
-                </nav>
-                <div class="container">
+                <div id="challenge_list" class="container py-4">
                     <div class="card" t-foreach="results" t-as="result">
                         <div class="card-body">
                             <a t-att-href="result.website_url"><t
@@ -22,14 +17,63 @@
             </div>
         </t>
     </template>
-    <template id="template_challenge_detail">
+    <template
+        id="template_challenge_list_header"
+        name="Crowdfunding list header"
+        inherit_id="template_challenge_list"
+        customize_show="True"
+    >
+        <div id="challenge_list" position="before">
+            <t
+                t-set="challenge_list_header_description"
+            >Edit the header of the crowdfunding list</t>
+            <div
+                id="challenge_list_header"
+                class="oe_structure"
+                t-att-data-editor-sub-message="challenge_list_header_description"
+            >
+                <nav class="navbar navbar-light border-top">
+                    <div class="container">
+                        Crowdfunding
+                    </div>
+                </nav>
+            </div>
+        </div>
+    </template>
+    <template
+        id="template_challenge_list_footer"
+        name="Crowdfunding list footer"
+        inherit_id="template_challenge_list"
+        customize_show="True"
+    >
+        <div id="challenge_list" position="after">
+            <t
+                t-set="challenge_list_footer_description"
+            >Edit the footer of the crowdfunding list</t>
+            <div
+                id="challenge_list_footer"
+                class="oe_structure oe_empty"
+                t-att-data-editor-sub-message="challenge_list_footer_description"
+            />
+        </div>
+    </template>
+    <template id="template_challenge_detail" name="Crowdfunding">
         <t t-call="website.layout">
             <t t-set="additional_title" t-value="object.name" />
             <div id="wrap">
+                <t t-call="website.record_cover">
+                    <t t-set="_record" t-value="object" />
+                    <t t-set="snippet_autofocus" t-value="True" />
+                    <t t-set="use_filters" t-value="True" />
+                    <t t-set="use_size" t-value="True" />
+                    <t t-set="display_opt_name">Challenge Cover</t>
+                    <div class="container">
+                        <h1 t-field="object.name" class="py-4" />
+                    </div>
+                </t>
                 <div class="container">
                     <section class="mb24">
                         <div class="container">
-                            <h1 t-field="object.name" />
                             <img
                                 t-attf-src="/web/image/crowdfunding.challenge/{{object.id}}/description_image"
                                 t-if="object.description_image"
@@ -66,11 +110,20 @@
                             </li>
                         </ul>
                     </section>
-                    <div id="discuss">
-                        <t t-call="portal.message_thread" />
-                    </div>
                 </div>
             </div>
         </t>
+    </template>
+    <template
+        id="template_challenge_detail_discuss"
+        name="Comments"
+        inherit_id="template_challenge_detail"
+        customize_show="True"
+    >
+        <div id="wrap" position="inside">
+            <div id="discuss" class="container">
+                <t t-call="portal.message_thread" />
+            </div>
+        </div>
     </template>
 </data>

--- a/crowdfunding_claim/templates/crowdfunding_challenge.xml
+++ b/crowdfunding_claim/templates/crowdfunding_challenge.xml
@@ -7,23 +7,22 @@
         inherit_id="crowdfunding.template_challenge_detail"
     >
         <xpath expr="//ul[hasclass('nav')]/li" position="before">
-                            <li t-if="object._can_claim()" class="nav-item m-1">
-                            <form
-                    t-attf-action="{{object.website_url}}/claim"
-                    method="post"
-                >
-                                <input
+            <li t-if="object._can_claim()" class="nav-item m-1">
+            <form t-attf-action="{{object.website_url}}/claim" method="post">
+                <input
                         type="hidden"
                         name="csrf_token"
                         t-att-value="request.csrf_token()"
                     />
-                                <button
-                        type="submit"
-                        class="btn btn-primary"
-                    >Claim</button>
-                            </form>
-                            </li>
+                <button type="submit" class="btn btn-primary">Claim</button>
+            </form>
+            </li>
         </xpath>
+    </template>
+    <template
+        id="template_challenge_detail_discuss"
+        inherit_id="crowdfunding.template_challenge_detail_discuss"
+    >
         <xpath expr="//div[@id='discuss']" position="attributes">
             <attribute name="t-if">not hide_discuss</attribute>
         </xpath>


### PR DESCRIPTION
@TumbaoJu now there's optional header and footer blocks where you can drop snippets into:

<img width="1919" height="877" alt="image" src="https://github.com/user-attachments/assets/dc03196a-8c99-4bbf-9a4f-a653e29165b9" />

While being at it, I also added support for Odoo's cover functionality like you have in blogs, and made comments optional.