### PR TITLE
[18.0][FIX] crowdfunding: be sure company_id is set by form

### DIFF
--- a/crowdfunding/models/crowdfunding_challenge.py
+++ b/crowdfunding/models/crowdfunding_challenge.py
@@ -157,7 +157,7 @@ class CrowdfundingChallenge(models.Model):
             self.env["res.company"].browse(
                 self.default_get(["company_id"]).get("company_id") or []
             )
-            or self.env.user.company
+            or self.env.company
         )
         return company.crowdfunding_default_fee_percentage
 

--- a/crowdfunding/tests/__init__.py
+++ b/crowdfunding/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_crowdfunding_backend
 from . import test_crowdfunding_frontend

--- a/crowdfunding/tests/test_crowdfunding_backend.py
+++ b/crowdfunding/tests/test_crowdfunding_backend.py
@@ -1,0 +1,14 @@
+import odoo
+import odoo.tests
+
+
+class TestCrowdfundingBackend(odoo.tests.HttpCase):
+    def test_create_non_multicompany(self):
+        """
+        Test that creating challenges works without multicompany group
+        """
+        self.env.user.groups_id -= self.env.ref("base.group_multi_company")
+        with odoo.tests.Form(self.env["crowdfunding.challenge"]) as form:
+            form.name = "testchallenge"
+            challenge = form.save()
+        self.assertTrue(challenge.exists())

--- a/crowdfunding/views/crowdfunding_challenge.xml
+++ b/crowdfunding/views/crowdfunding_challenge.xml
@@ -143,6 +143,7 @@
                                 </group>
                                 <group name="right">
                                     <field name="pledge_default_amount" />
+                                    <field name="company_id" invisible="True" />
                                     <field
                                         name="company_id"
                                         groups="base.group_multi_company"


### PR DESCRIPTION
the problem here is that without the `company_id` field on forms, a computation is triggered with empty `company_id`, raising an error about currency_id not being set.

If you just do `env['crowdfunding.challenge'].create({})` in code this works because all fields are resolved before this computation is called.